### PR TITLE
[Abandoned] Addition on CircleCI DNS host modifications so all integration can be enabled

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -131,11 +131,11 @@ commands:
       - run:
           name: Add VPN resource hostname-to-IP mapping to hosts file
           command: |
-            echo '# MGM VPN resources needed for integration tests;
-#Manual fix until DNS is established by networking team.
-172.30.34.41 eaiws-qa.mgmresorts.local
-10.199.1.156 auroraws-qa.mgmresorts.local
-10.114.75.131 tibcows-dmpdev.mgmresorts.local' | sudo tee -a /etc/hosts
+            echo '# MGM VPN resources needed for integration tests' | sudo tee -a /etc/hosts
+            echo '# Manual fix until DNS is established by networking team.' | sudo tee -a /etc/hosts
+            echo '172.30.34.41 eaiws-qa.mgmresorts.local' | sudo tee -a /etc/hosts
+            echo '10.199.1.156 auroraws-qa.mgmresorts.local' | sudo tee -a /etc/hosts
+            echo '10.114.75.131 tibcows-dmpdev.mgmresorts.local'  | sudo tee -a /etc/hosts
             cat /etc/hosts
 
   deploy:

--- a/microservices.yml
+++ b/microservices.yml
@@ -125,6 +125,19 @@ commands:
             echo 'export LEGIC_USERNAME=$(aws ssm get-parameters --name "$SSM_PATH_PREFIX/Legic/username" --with-decryption | jq .Parameters[0].Value | sed "s/\"//g")' >> $BASH_ENV
             echo 'export LEGIC_PASSWORD=$(aws ssm get-parameters --name "$SSM_PATH_PREFIX/Legic/password" --with-decryption | jq .Parameters[0].Value | sed "s/\"//g")' >> $BASH_ENV
 
+  add-vpn-hostnames:
+    description: Add VPN resource hostname-to-IP mapping to hosts file
+    steps:
+      - run:
+          name: Add VPN resource hostname-to-IP mapping to hosts file
+          command: |
+            echo '# MGM VPN resources needed for integration tests;
+#Manual fix until DNS is established by networking team.
+172.30.34.41 eaiws-qa.mgmresorts.local
+10.199.1.156 auroraws-qa.mgmresorts.local
+10.114.75.131 tibcows-dmpdev.mgmresorts.local' | sudo tee -a /etc/hosts
+            cat /etc/hosts
+
   deploy:
     description: Deploy task definition in ECR to ECS Service
     steps:
@@ -190,6 +203,7 @@ jobs:
           after-vpn-steps:
             - checkout
             - populate-env-vars-into-job
+            - add-vpn-hostnames
             - attach-built-docker-image
             - run-integration-tests-in-docker
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
This approach was abandoned for this one: https://github.com/MGMResorts/api/pull/85
See @misiek-sf 's comment below.

### Existing Behavior
Enabling integration tests fails due to hostnames for MGM VPN resources not being reachable via DNS. 

### New Behavior
Adds several IPs with hostname mappings to to `/etc/hosts` file of this common orb so any microservices build can use it to reach VPN resources. It also gives us a centralized place to track the IPs we need to hard-code until the DNS resolution is established.
 
This is the interim approach until DNS resolution is established by MGM IT.

Example of it being used in a service to allow integ. tests to reach VPN resources: https://github.com/MGMResorts/devices/blob/f/SRV-258/Makefile#L3
~