### PR TITLE
Add a command to run dns checks for all services

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -134,15 +134,16 @@ commands:
             make deploy
 
   run-dependent-service-dns-tests:
-    description: Test dependent service DNS availability
+    description: Print DNS server and test dependent service DNS availability
     steps:
       - run:
-          name: Ping dependent service hostnames to check if DNS is reachable
+          name: Run dig and check if vpn services have A records in DNS
           command: |
-            ping eaiws-qa.mgmresorts.local -c 5
-            ping auroraws-qa.mgmresorts.local -c 5
-            ping tibcows-dmpdev.mgmresorts.local -c 5
-            ping v00watlappbg01r.mgmmirage.org -c 5
+            dig
+            host -t a eaiws-qa.mgmresorts.local
+            host -t a auroraws-qa.mgmresorts.local
+            host -t a tibcows-dmpdev.mgmresorts.local
+            host -t a v00watlappbg01r.mgmmirage.org
 
 jobs:
   npm-audit:

--- a/microservices.yml
+++ b/microservices.yml
@@ -147,6 +147,7 @@ commands:
             host -t a auroraws-qa.mgmresorts.local
             host -t a tibcows-dmpdev.mgmresorts.local
             host -t a v00watlappbg01r.mgmmirage.org
+            host -t a token-fp.mgmresorts.local
 
 jobs:
   npm-audit:

--- a/microservices.yml
+++ b/microservices.yml
@@ -133,6 +133,17 @@ commands:
           command: |
             make deploy
 
+  run-dependent-service-dns-tests:
+    description: Test dependent service DNS availability
+    steps:
+      - run:
+          name: Ping dependent service hostnames to check if DNS is reachable
+          command: |
+            ping eaiws-qa.mgmresorts.local -c 5
+            ping auroraws-qa.mgmresorts.local -c 5
+            ping tibcows-dmpdev.mgmresorts.local -c 5
+            ping v00watlappbg01r.mgmmirage.org -c 5
+
 jobs:
   npm-audit:
     docker:

--- a/microservices.yml
+++ b/microservices.yml
@@ -134,12 +134,15 @@ commands:
             make deploy
 
   run-dependent-service-dns-tests:
-    description: Print DNS server and test dependent service DNS availability
+    description: Run DNS checks for VPN-based services
     steps:
       - run:
-          name: Run dig and check if vpn services have A records in DNS
+          name: Run dig for dns info
           command: |
             dig
+      - run:
+          name: Check if vpn services have A records in DNS
+          command: |
             host -t a eaiws-qa.mgmresorts.local
             host -t a auroraws-qa.mgmresorts.local
             host -t a tibcows-dmpdev.mgmresorts.local

--- a/microservices.yml
+++ b/microservices.yml
@@ -143,11 +143,11 @@ commands:
       - run:
           name: Check if vpn services have A records in DNS
           command: |
-            host -t a eaiws-qa.mgmresorts.local
-            host -t a auroraws-qa.mgmresorts.local
-            host -t a tibcows-dmpdev.mgmresorts.local
-            host -t a v00watlappbg01r.mgmmirage.org
-            host -t a token-fp.mgmresorts.local
+            dig eaiws-qa.mgmresorts.local
+            dig auroraws-qa.mgmresorts.local
+            dig tibcows-dmpdev.mgmresorts.local
+            dig v00watlappbg01r.mgmmirage.org
+            dig token-fp.mgmresorts.local
 
 jobs:
   npm-audit:
@@ -225,3 +225,9 @@ jobs:
       - populate-env-vars-into-job
       - populate-secret-ssm-env-vars
       - deploy
+
+  # DNS checks for scheduled nightly integration test runs
+  run-dns-checks:
+    executor: vpn/aws
+    steps:
+      - run-dependent-service-dns-tests


### PR DESCRIPTION
### New Behavior
Add a new command (`run-dependent-service-dns-tests`) which checks if hostnames of dependent VPN services such as TIBCO are reachable. This is the DNS check which is intended to run along with nightly tests for each service.
