### PR TITLE
Dns checks

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -143,11 +143,11 @@ commands:
       - run:
           name: Check if vpn services have A records in DNS
           command: |
-            dig eaiws-qa.mgmresorts.local
-            dig auroraws-qa.mgmresorts.local
-            dig tibcows-dmpdev.mgmresorts.local
-            dig v00watlappbg01r.mgmmirage.org
-            dig token-fp.mgmresorts.local
+            host -t a eaiws-qa.mgmresorts.local
+            host -t a auroraws-qa.mgmresorts.local
+            host -t a tibcows-dmpdev.mgmresorts.local
+            host -t a v00watlappbg01r.mgmmirage.org
+            host -t a token-fp.mgmresorts.local
 
 jobs:
   npm-audit:

--- a/microservices.yml
+++ b/microservices.yml
@@ -133,7 +133,7 @@ commands:
           command: |
             make deploy
 
-  run-dependent-service-dns-tests:
+  run-dependent-service-ip-tests:
     description: Run DNS checks for VPN-based services
     steps:
       - run:
@@ -143,12 +143,11 @@ commands:
       - run:
           name: Check if vpn services have A records in DNS
           command: |
-            host -t a eaiws-qa.mgmresorts.local
-            host -t a auroraws-qa.mgmresorts.local
-            host -t a tibcows-dmpdev.mgmresorts.local
-            host -t a v00watlappbg01r.mgmmirage.org
-            host -t a token-fp.mgmresorts.local
-
+            host 172.30.34.41
+            host 10.199.1.156
+            host 10.114.75.131
+            host 10.199.8.54
+            host 10.191.113.10
 jobs:
   npm-audit:
     docker:
@@ -232,4 +231,4 @@ jobs:
     steps:
       - vpn/with-vpn-connection:
           after-vpn-steps:
-            - run-dependent-service-dns-tests
+            - run-dependent-service-ip-tests

--- a/microservices.yml
+++ b/microservices.yml
@@ -230,4 +230,6 @@ jobs:
   run-dns-checks:
     executor: vpn/aws
     steps:
-      - run-dependent-service-dns-tests
+      - vpn/with-vpn-connection:
+          after-vpn-steps:
+            - run-dependent-service-dns-tests


### PR DESCRIPTION
Some corrections from previous PR (#6 )

- Add back `host` command. Dig does not exit with proper code. Otherwise, they are identical.
- We need to check if IP addresses are reachable, not hostnames. Hostnames always fail currently and IPs are used in integration tests. The purpose is to run daily to catch if IPs change.
- Run commands _after_ VPN is established.

Unchanged:
- Dig (DNS server) info is still outputted
- DNS is still run per dependency (IP instead of hostname)