### PR TITLE
remove ip checks as they are duplicate value from integ tests running

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -133,21 +133,6 @@ commands:
           command: |
             make deploy
 
-  run-dependent-service-ip-tests:
-    description: Run DNS checks for VPN-based services
-    steps:
-      - run:
-          name: Run dig for dns info
-          command: |
-            dig
-      - run:
-          name: Check if vpn services have A records in DNS
-          command: |
-            host 172.30.34.41
-            host 10.199.1.156
-            host 10.114.75.131
-            host 10.199.8.54
-            host 10.191.113.10
 jobs:
   npm-audit:
     docker:
@@ -224,11 +209,3 @@ jobs:
       - populate-env-vars-into-job
       - populate-secret-ssm-env-vars
       - deploy
-
-  # DNS checks for scheduled nightly integration test runs
-  run-dns-checks:
-    executor: vpn/aws
-    steps:
-      - vpn/with-vpn-connection:
-          after-vpn-steps:
-            - run-dependent-service-ip-tests

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "1.0.2"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Revert the changes from IP checks for two reasons:

- It is not needed as nightly integration tests that will run in each service will warn us when IPs fail (which is the intent of the IP-based check).
- It does not work in circleci as expected for 2 of 5 IPs listed.