### PR TITLE
Report test results to CircleCI

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -104,6 +104,14 @@ commands:
           name: Run integration tests in docker container
           command: |
             make ci-test-integration
+      - run:
+          name: Store test results as XML for CircleCI
+          when: always
+          command: |
+            npm i -g cucumber-junit
+            cat ./integration-test-results.json | cucumber-junit > integration-tests-output.xml
+      - store_test_results:
+          path: ./integration-tests-output.xml
   run-lint:
     description: Runs lint
     steps:

--- a/microservices.yml
+++ b/microservices.yml
@@ -101,7 +101,7 @@ commands:
           when: always
           command: |
             npm i -g cucumber-junit
-            cat ./unit-test-results.json | cucumber-junit > ~/unit-tests-output.xml
+            cat ./reports/unit-test-results.json | cucumber-junit > ~/unit-tests-output.xml
       - store_test_results:
           path: ~/unit-tests-output.xml
 
@@ -117,7 +117,7 @@ commands:
           when: always
           command: |
             npm i -g cucumber-junit
-            cat ./integration-test-results.json | cucumber-junit > integration-tests-output.xml
+            cat ./reports/integration-test-results.json | cucumber-junit > integration-tests-output.xml
       - store_test_results:
           path: ./integration-tests-output.xml
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -101,11 +101,11 @@ commands:
           when: always
           command: |
             npm i -g cucumber-junit
-            cat ./reports/unit-test-results.json | cucumber-junit > ~/unit-tests-output.xml
+            cat ./reports/unit-test-results.json | cucumber-junit > ./reports/unit-tests-output.xml
       - store_test_results:
-          path: ~/unit-tests-output.xml
+          path: ./reports
       - store_artifacts:
-          path: ~/unit-tests-output.xml
+          path: ./reports
 
   run-integration-tests-in-docker:
     description: Runs integration tests in docker container
@@ -119,11 +119,11 @@ commands:
           when: always
           command: |
             npm i -g cucumber-junit
-            cat ./reports/integration-test-results.json | cucumber-junit > integration-tests-output.xml
+            cat ./reports/integration-test-results.json | cucumber-junit > ./reports/integration-tests-output.xml
       - store_test_results:
-          path: ./integration-tests-output.xml
+          path: ./reports
       - store_artifacts:
-          path: ./integration-tests-output.xml
+          path: ./reports
 
   run-lint:
     description: Runs lint

--- a/microservices.yml
+++ b/microservices.yml
@@ -104,6 +104,8 @@ commands:
             cat ./reports/unit-test-results.json | cucumber-junit > ~/unit-tests-output.xml
       - store_test_results:
           path: ~/unit-tests-output.xml
+      - store_artifacts:
+          path: ~/unit-tests-output.xml
 
   run-integration-tests-in-docker:
     description: Runs integration tests in docker container
@@ -119,6 +121,8 @@ commands:
             npm i -g cucumber-junit
             cat ./reports/integration-test-results.json | cucumber-junit > integration-tests-output.xml
       - store_test_results:
+          path: ./integration-tests-output.xml
+      - store_artifacts:
           path: ./integration-tests-output.xml
 
   run-lint:

--- a/microservices.yml
+++ b/microservices.yml
@@ -96,6 +96,14 @@ commands:
           name: Run unit tests in docker container
           command: |
             make ci-test-unit
+      - run:
+          name: Store test results as XML for CircleCI
+          when: always
+          command: |
+            npm i -g cucumber-junit
+            cat ./unit-test-results.json | cucumber-junit > ~/unit-tests-output.xml
+      - store_test_results:
+          path: ~/unit-tests-output.xml
 
   run-integration-tests-in-docker:
     description: Runs integration tests in docker container
@@ -112,6 +120,7 @@ commands:
             cat ./integration-test-results.json | cucumber-junit > integration-tests-output.xml
       - store_test_results:
           path: ./integration-tests-output.xml
+
   run-lint:
     description: Runs lint
     steps:

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
## Existing behaviour

Tests (unit and integration) run and output lots of information in circleci but do not leverage CircleCI's test output harvesting.

## New intended behaviour

- Pickup test JSON file output and transform it to junit (XML) output
- Be able to leverage CircleCI "Test Summary" feature for succinctness in build output and analytics in Insights.


## Note
This PR depends on each service PR for the same change.

## Checklist

- [x] Performed a self-review.
- [x] Assigned reviewers and set myself as Assignee
- [ ] Changed a documentation ([ x ] `[ x ]` if not required).
- [ ] I have added tests ([ x ] `[ x ]` if no required).
