### PR TITLE
Feature/SRV-347: Use Okta CLI to establish AWS session

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ circleci orb publish ./microservices.yml mgmorbs/microservices@dev:latest
 
 This orb:
 - depends on the [vpn orb](https://github.com/MGMDV-Orbs/vpn/).
+- depends on [Okta AWS Assume Role CLI](https://github.com/oktadeveloper/okta-aws-cli-assume-role) to setup a trusted session for AWS CLI.
 - exposes Jobs that can be used as drop-in with workflows (see Usage section)
 - exposes underlying discrete Steps used by these Jobs
 - requires usage of `microservices` context (see Usage section)

--- a/microservices.yml
+++ b/microservices.yml
@@ -163,6 +163,58 @@ commands:
           command: |
             make deploy
 
+  install-okta-aws-cli:
+    description: Install Okta Assume Role Client and tooling
+    steps:
+      - attach_workspace:
+          at: ~/build-workspace
+      - run:
+          name: Install JDK 8 for Okta Assume Role CLI
+          command: |
+            if type -p java; then
+              echo Java already installed
+              java -version
+            else
+              sudo apt install openjdk-8-jdk
+            fi
+      - run:
+          name: Install Okta Assume Role CLI tool
+          command: |
+            mkdir ~/.okta/ && cd "$_"
+            PREFIX=~/.okta bash <(curl -fsSL https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh) -i
+      - run:
+          name: Create okta configuration file for target AWS account
+          command: |
+            cd ~/.okta/
+            case "$CIRCLE_BRANCH" in
+            "prod")
+                echo "Using Prod Config - $OKTA_AWS_PROD_ROLE_TO_ASSUME"
+                OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_PROD_ROLE_TO_ASSUME
+                ;;
+            *)
+                echo "Using NON-prod Config - $OKTA_AWS_PROD_ROLE_TO_ASSUME"
+                OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_NONPROD_ROLE_TO_ASSUME
+                ;;
+            esac
+
+            echo "OKTA_ORG=$OKTA_ORG
+            OKTA_AWS_APP_URL=$OKTA_AWS_APP_URL
+            OKTA_USERNAME=$OKTA_USERNAME
+            OKTA_PASSWORD_CMD=/bin/echo $OKTA_PASSWORD
+            OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_ROLE_TO_ASSUME
+            OKTA_PROFILE=$OKTA_PROFILE
+            OKTA_STS_DURATION=$OKTA_STS_DURATION
+            OKTA_BROWSER_AUTH=false" > config.properties
+      - run:
+          name: Output the IAM Identity of AWS Role trusted by Okta
+          command: |
+            ls -la ~/.okta/
+            java -jar ~/.okta/okta-aws-cli.jar sts get-caller-identity
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - .okta
+
 jobs:
   npm-audit:
     docker:
@@ -181,8 +233,9 @@ jobs:
   setup-env:
     executor: vpn/aws
     steps:
-      - print-diagnostics
+      - install-okta-aws-cli
       - fetch-environment-variables-from-s3
+      - print-diagnostics
 
   # Step 2: Build and tag docker image
   build-image:

--- a/microservices.yml
+++ b/microservices.yml
@@ -215,6 +215,28 @@ commands:
           paths:
             - .okta
 
+  populate-okta-cli:
+    description: Pull in okta cli jar
+    steps:
+      - attach_workspace:
+          at: ~/build-workspace
+      - run:
+          name: Run jar once to establish session for aws cli
+          command: |
+            # cleanup previous session to avoid initial failures
+            rm -rf ~/.okta/
+            rm -f ~/build-workspace/.okta/cookies.properties
+            rm -f ~/build-workspace/.okta/.current-session
+            rm -f ~/build-workspace/.okta/profiles
+
+            # move jar to home folder to avoid static
+            # reference issues within okta cli
+            cp -r ~/build-workspace/.okta ~/.okta
+
+            # Establish aws session with first command
+            # and print out the identity of th user & account
+            java -jar ~/.okta/okta-aws-cli.jar sts get-caller-identity
+
 jobs:
   npm-audit:
     docker:
@@ -243,6 +265,7 @@ jobs:
     steps:
       - checkout
       - populate-env-vars-into-job
+      - populate-okta-cli
       - build-and-tag-docker-image
 
   # Step 4: Push images to ECR
@@ -251,6 +274,7 @@ jobs:
     steps:
       - checkout
       - populate-env-vars-into-job
+      - populate-okta-cli
       - attach-built-docker-image
       - push-built-image-to-ecr
 
@@ -258,6 +282,7 @@ jobs:
   run-unit-tests:
     executor: vpn/aws
     steps:
+      - populate-okta-cli
       - vpn/with-vpn-connection:
           after-vpn-steps:
             - checkout
@@ -270,6 +295,7 @@ jobs:
   run-integration-tests:
     executor: vpn/aws
     steps:
+      - populate-okta-cli
       - vpn/with-vpn-connection:
           after-vpn-steps:
             - checkout
@@ -292,5 +318,6 @@ jobs:
     steps:
       - checkout
       - populate-env-vars-into-job
+      - populate-okta-cli
       - populate-secret-ssm-env-vars
       - deploy

--- a/microservices.yml
+++ b/microservices.yml
@@ -81,14 +81,6 @@ commands:
           command: |
             make push-image-to-ecr
 
-  pull-test-configs:
-    description: Pull env vars needed for tests
-    steps:
-      - run:
-          name: Pull .env files referenced by unit and integ tests
-          command: |
-            aws s3 sync "s3://mgmresorts-services-configurations/$CIRCLE_PROJECT_REPONAME/integration-test-configs/" ./
-
   run-unit-tests-in-docker:
     description: Runs tests in docker container
     steps:
@@ -237,6 +229,27 @@ commands:
             # and print out the identity of th user & account
             java -jar ~/.okta/okta-aws-cli.jar sts get-caller-identity
 
+  pull-test-configs-from-s3:
+    description: Pull env vars needed for tests
+    steps:
+      - run:
+          name: Pull .env files referenced by unit and integ tests
+          command: |
+            mkdir test-suite-configs
+            aws s3 sync "s3://mgmresorts-services-configurations/$CIRCLE_PROJECT_REPONAME/integration-test-configs/" test-suite-configs/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - test-suite-configs
+
+  populate-test-configs-from-workspace:
+    description: Pull test suite env files from workspace
+    steps:
+      - run:
+          name: Copy .test suite env files to local directory
+          command: |
+            cp build-workspace/test-suite-configs/* ./
+
 jobs:
   npm-audit:
     docker:
@@ -287,8 +300,7 @@ jobs:
           after-vpn-steps:
             - checkout
             - populate-env-vars-into-job
-            - pull-test-configs
-            - attach-built-docker-image
+            - populate-test-configs-from-workspace
             - run-unit-tests-in-docker
 
   # Step 3b: Verify that integration tests are passing
@@ -300,8 +312,7 @@ jobs:
           after-vpn-steps:
             - checkout
             - populate-env-vars-into-job
-            - pull-test-configs
-            - attach-built-docker-image
+            - populate-test-configs-from-workspace
             - run-integration-tests-in-docker
 
   # Step 3c: Verify that lint is passing

--- a/microservices.yml
+++ b/microservices.yml
@@ -12,9 +12,9 @@ commands:
           command: |
             echo NodeJS: `node -v`
             echo NPM: `npm -v`
-            echo AWS CLI: `aws --version`
+            echo `aws --version`
+            echo "Okta CLI Version: " `ls ~/.okta/*.jar | head -1`
             echo Docker: `docker -v`
-            echo Access Key: $AWS_ACCESS_KEY_ID
             echo Git Branch/Commit: $CIRCLE_BRANCH/$CIRCLE_SHA1
 
   fetch-environment-variables-from-s3:

--- a/microservices.yml
+++ b/microservices.yml
@@ -270,6 +270,7 @@ jobs:
     steps:
       - install-okta-aws-cli
       - fetch-environment-variables-from-s3
+      - pull-test-configs-from-s3
       - print-diagnostics
 
   # Step 2: Build and tag docker image

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "1.0.3"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Existing Behavior
- AWS CLI uses superformula user's access id and secret key via env. variables from `microservices` context

## New Intended Behavior
- Okta Assume Role CLI is installed and used to establish CLI session via AWS SAML Trust relationship
- All existing AWS commands will leverage the session generated by Okta CLI rather than credentials

These changes should now support deployment to production.

Please see this working example here on a branch of rooms service:
- CircleCI Build: https://circleci.com/workflow-run/08cb8260-555c-403a-90c4-10adc4d592c8
- Code: https://github.com/MGMResorts/rooms/compare/develop...poc/SRV-347

## Related Story
https://mgmdigitalventures.atlassian.net/browse/SRV-347

## Non-prod Rollout Plan
1. Merge this PR and publish orb v2.0
2. Create new context named `microservices-okta` (@codin-mgm)
   - New context should copy all `microservices` context env vars except: 
         1. delete AWS access & secret credentials
         2. add new okta env vars (provided to Will and Codin)
3. Update all services to orb 2.0 and new context. (Afaq & @patrick-sf )