### PR TITLE
use dynamic s3 bucket name based on aws account

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -254,7 +254,7 @@ commands:
     description: Set static AWS resource names
     steps:
       - run:
-          name: Pull .env files referenced by unit and integ tests
+          name: Set static AWS resource names based on AWS account
           command: |
             case "$CIRCLE_BRANCH" in
             "prod")

--- a/microservices.yml
+++ b/microservices.yml
@@ -258,12 +258,12 @@ commands:
           command: |
             case "$CIRCLE_BRANCH" in
             "prod")
-                echo "Using Prod resources"
-                echo "export SVC_CONFIG_S3_BUCKET=mgmresorts-services-configurations" >> $BASH_ENV
+                echo "Using prod resources"
+                echo "export SVC_CONFIG_S3_BUCKET=mgmri-mobapp-production/services-configurations" >> $BASH_ENV
                 ;;
             *)
                 echo "Using non-prod resources"
-                echo "export SVC_CONFIG_S3_BUCKET=mgmri-mobapp-production/services-configurations" >> $BASH_ENV
+                echo "export SVC_CONFIG_S3_BUCKET=mgmresorts-services-configurations" >> $BASH_ENV
                 ;;
             esac
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -33,7 +33,7 @@ commands:
               return 1
             }
             config_branch=$(branchIn $CIRCLE_BRANCH "${known_branches[@]}" && echo $CIRCLE_BRANCH || echo develop)
-            aws s3 cp "s3://mgmresorts-services-configurations/$CIRCLE_PROJECT_REPONAME/$config_branch.json" ./environment/config.json
+            aws s3 cp "s3://$SVC_CONFIG_S3_BUCKET/$CIRCLE_PROJECT_REPONAME/$config_branch.json" ./environment/config.json
       - persist_to_workspace:
           root: .
           paths:
@@ -236,7 +236,7 @@ commands:
           name: Pull .env files referenced by unit and integ tests
           command: |
             mkdir test-suite-configs
-            aws s3 sync "s3://mgmresorts-services-configurations/$CIRCLE_PROJECT_REPONAME/integration-test-configs/" test-suite-configs/
+            aws s3 sync "s3://$SVC_CONFIG_S3_BUCKET/$CIRCLE_PROJECT_REPONAME/integration-test-configs/" test-suite-configs/
       - persist_to_workspace:
           root: .
           paths:
@@ -249,6 +249,23 @@ commands:
           name: Copy .test suite env files to local directory
           command: |
             cp build-workspace/test-suite-configs/* ./
+
+  set-aws-account-specific-resources:
+    description: Set static AWS resource names
+    steps:
+      - run:
+          name: Pull .env files referenced by unit and integ tests
+          command: |
+            case "$CIRCLE_BRANCH" in
+            "prod")
+                echo "Using Prod resources"
+                echo "export SVC_CONFIG_S3_BUCKET=mgmresorts-services-configurations" >> $BASH_ENV
+                ;;
+            *)
+                echo "Using non-prod resources"
+                echo "export SVC_CONFIG_S3_BUCKET=mgmri-mobapp-production/services-configurations" >> $BASH_ENV
+                ;;
+            esac
 
 jobs:
   npm-audit:
@@ -268,6 +285,7 @@ jobs:
   setup-env:
     executor: vpn/aws
     steps:
+      - set-aws-account-specific-resources
       - install-okta-aws-cli
       - fetch-environment-variables-from-s3
       - pull-test-configs-from-s3

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Existing Behavior
This orb is hard-coded to expect S3 buckets in non-prod account.

## New Intended Behavior
This orb will now dynamically look in appropriate account for prod branch builds in prod AWS account 
and in non-prod S3 for all other branches.