### PR TITLE
add prod to known-branches; bump patch version

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -26,7 +26,7 @@ commands:
             mkdir environment
             echo Using build env var until S3 bucket is created
             echo Use develop config for all but develop/qa4/uat/preprod branches
-            known_branches=(develop qa4 uat preprod)
+            known_branches=(develop qa4 uat preprod prod)
             branchIn () {
               local e
               for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.1.0"
+  "version": "2.1.1"
 }


### PR DESCRIPTION
## Existing behavior
prod is not a "known_branch".

## New Intended behavior
Patch existing change-set to add `prod` to known branches so it will be recognized as unique in the CircleCI build.