### PR TITLE
hotfix okta-aws-assume tool for v1.0.10

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -173,7 +173,10 @@ commands:
           name: Install Okta Assume Role CLI tool
           command: |
             mkdir ~/.okta/ && cd "$_"
-            PREFIX=~/.okta bash <(curl -fsSL https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/master/bin/install.sh) -i
+            PREFIX=~/.okta bash <(curl -fsSL https://raw.githubusercontent.com/oktadeveloper/okta-aws-cli-assume-role/v1.0.10/bin/install.sh) -i
+            curl -LO curl -LO https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v1.0.10/okta-aws-cli-1.0.10.jar
+            rm okta-aws-cli.jar
+            ln -s okta-aws-cli-1.0.10.jar okta-aws-cli.jar
       - run:
           name: Create okta configuration file for target AWS account
           command: |

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }


### PR DESCRIPTION
there was `okta-aws-cli-assume-role` release yesterday, and it is breaking change, so our builds stopped working

this PR is "fixing" that problem by "installing" older release (somewhat in the hacky way)

we should go back to this and fix it properly 