### PR TITLE
f/SRV-364: Adds support for publishing of lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Commands in this Orb are discrete, common operations across services, with clear
 Jobs exposed by this Orb are intended to be for drop-in usage of a subset of exposed commands.
 
 ### Lambdas
-Use the `publish-aws-lambdas` job found in this drop-in CircleCI configuration with the microservices by adding the following the CircleCI configuration:
+Use the `publish-aws-lambdas` job found in this drop-in CircleCI configuration with the microservices by adding the following to the CircleCI configuration:
 
 ```
 - ms/publish-aws-lambdas:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Orb: microservices
+
 An orb containing common abstracted commands and jobs for building and deploying MGM microservices.
 
 https://circleci.com/orbs/registry/orb/mgmorbs/microservices
@@ -24,15 +25,15 @@ workflows:
       - ms/setup-env:
           context: microservices
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/build-image:
           context: microservices
           requires:
             - ms/setup-env
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/push-image:
           context: microservices
           requires:
@@ -42,30 +43,30 @@ workflows:
             - ms/run-lint
             - ms/npm-audit
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/run-unit-tests:
           context: microservices
           requires:
             - ms/build-image
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/run-integration-tests:
           context: microservices
           requires:
             - ms/build-image
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/run-lint:
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - ms/npm-audit:
           filters:
-              tags:
-                only: /^v.*/
+            tags:
+              only: /^v.*/
       - hold:
           type: approval
           requires:
@@ -93,6 +94,7 @@ workflows:
 ```
 
 ### Advanced Usage with Commands
+
 You may also choose to call the discrete commands exposed by this orb directly within your inline jobs.
 
 All commands exposed by this Orb can be found [here](#orb-registry-url)(TODO).
@@ -111,16 +113,17 @@ jobs:
     steps:
       - ms/print-diagnostics
       - run: echo "Custom step after ms Orb command"
-
 ```
 
 ## Contributing
 
 ### Changes
+
 All changes should can made in `microservices.yml`.
 
 ### Publishing
-Before pubishing, changes should be tested via:
+
+Before publishing, changes should be tested via:
 
 ```bash
 # validates circleci orb syntax
@@ -142,6 +145,7 @@ circleci orb publish ./microservices.yml mgmorbs/microservices@dev:latest
 ## Architecture
 
 This orb:
+
 - depends on the [vpn orb](https://github.com/MGMDV-Orbs/vpn/).
 - depends on [Okta AWS Assume Role CLI](https://github.com/oktadeveloper/okta-aws-cli-assume-role) to setup a trusted session for AWS CLI.
 - exposes Jobs that can be used as drop-in with workflows (see Usage section)
@@ -149,15 +153,18 @@ This orb:
 - requires usage of `microservices` context (see Usage section)
 
 ### Commands
+
 Commands in this Orb are discrete, common operations across services, with clear descriptions, and are parameterized for extensibility.
 
 ### Jobs
+
 Jobs exposed by this Orb are intended to be for drop-in usage of a subset of exposed commands.
 
 ### Lambdas
+
 Use the `publish-aws-lambdas` job found in this drop-in CircleCI configuration with the microservices by adding the following to the CircleCI configuration:
 
-```
+```yaml
 - ms/publish-aws-lambdas:
     context: microservices-okta
     requires:
@@ -172,14 +179,15 @@ Use the `publish-aws-lambdas` job found in this drop-in CircleCI configuration w
 
 After updating the CircleCI configuration, create a directory named `faas` in the root level and add a lambda directory structure following this example:
 
-```
-faas
-  - main.tf
-  - { lambdaName }
-    - src
-      - { files for lambda code }
-      - package.json (optional)
-    - main.tf
+```console
+.
+|-- faas
+|   |-- main.tf
+|   |-- { lambdaName }
+|   |-- src
+|   |  |-- { files for lambda code }
+|   |  |-- package.json (optional)
+|   `-- main.tf
 ```
 
 `faas/main.tf` is required as the terraform entrypoint where all project resources are referenced as [Terraform Modules](https://www.terraform.io/docs/configuration/modules.html).
@@ -240,5 +248,17 @@ resource "aws_lambda_alias" "live" {
   name             = "live"
   function_name    = "${aws_lambda_function.activate_profile.arn}"
   function_version = "${aws_lambda_function.activate_profile.version}"
+}
+
+# optional and not required but useful
+resource "aws_lambda_permission" "apigw_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_alias.live.arn}"
+  principal     = "apigateway.amazonaws.com"
+
+  # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
+  # source_arn = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}/${aws_api_gateway_resource.resource.path}"
+  source_arn = "arn:aws:execute-api:us-west-2:705869507755:pwzejzn6yk/authorizers/s8xu2r"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ workflows:
           requires:
             - hold
             - ms/push-image
+      - ms/publish-aws-lambdas:
+          context: microservices-okta
+          requires:
+            - ms/setup-env
+            - ms/build-image
+            - ms/run-unit-tests
+            - ms/run-integration-tests
+            - ms/run-lint
+          filters:
+            tags:
+              only: /^v.*/
 ```
 
 ### Advanced Usage with Commands
@@ -142,3 +153,32 @@ Commands in this Orb are discrete, common operations across services, with clear
 
 ### Jobs
 Jobs exposed by this Orb are intended to be for drop-in usage of a subset of exposed commands.
+
+### Lambdas
+Use the `publish-aws-lambdas` job found in this drop-in CircleCI configuration with the microservices by adding the following the CircleCI configuration:
+
+```
+- ms/publish-aws-lambdas:
+    context: microservices-okta
+    requires:
+      - ms/setup-env
+      - ms/run-unit-tests
+      - ms/run-integration-tests
+      - ms/run-lint
+    filters:
+      tags:
+        only: /^v.*/
+```
+
+After updating the CircleCI configuration, create a directory named `faas` in the root level and add a lambda directory structure following this example:
+
+```
+faas
+  - { lambdaName }
+    - src
+      - { files for lambda code }
+      - package.json (optional)
+  - main.tf
+```
+
+`main.tf` is required as the terraform entrypoint where resources are created/declared.

--- a/microservices.yml
+++ b/microservices.yml
@@ -322,7 +322,7 @@ commands:
               # envsubst is used instead (inline variables)
               terraform {
                 backend "s3" {
-                  bucket  = "${S3_BUCKET}"
+                  bucket  = "${TERRAFORM_STATE_S3_BUCKET}"
                   key     = "${NODE_ENV}/${CIRCLE_PROJECT_REPONAME}.json"
                   region  = "${AWS_DEFAULT_REGION}"
                   profile = "${AWS_DEFAULT_PROFILE}"

--- a/microservices.yml
+++ b/microservices.yml
@@ -350,7 +350,7 @@ commands:
               cd $lambdaDir/src
               if [[ -e package.json && -e package-lock.json ]]
               then
-                npm ci
+                NODE_ENV=production npm ci
               fi
               cd -
             done

--- a/microservices.yml
+++ b/microservices.yml
@@ -284,6 +284,10 @@ commands:
             unzip terraform_0.11.13_linux_amd64.zip
             sudo mv terraform /usr/local/bin/
             terraform --version
+            mkdir $HOME/.terraform.d/plugin-cache
+            echo 'export TF_IN_AUTOMATION=true' >> $BASH_ENV
+            echo 'export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache' >> $BASH_ENV
+
             rm *
 
   setup-each-lambda-env:
@@ -292,8 +296,6 @@ commands:
       - run:
           name: Populate environment variables reused across lambda steps
           command: |
-            echo 'export TF_IN_AUTOMATION=true' >> $BASH_ENV
-            echo 'export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache'
             echo 'export LAMBDA_DIRECTORIES=$(find ./faas/ -mindepth 1 -maxdepth 1 -type d)' >> $BASH_ENV
       - run:
           name: Map service configuration to terraform tfvar files

--- a/microservices.yml
+++ b/microservices.yml
@@ -278,12 +278,21 @@ commands:
       - run:
           name: Install terraform and update npm
           command: |
-            npm i -g npm@latest
+            # use node version to match lambda
+            source ~/.bashrc
+            nvm install 8.10
+            nvm use 8.10
 
+            # install npm version with npm ci
+            npm i -g npm@5.7
+
+            # install terraform
             wget https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip
             unzip terraform_0.11.13_linux_amd64.zip
             sudo mv terraform /usr/local/bin/
             terraform --version
+
+            # terraform plugin cache
             mkdir $HOME/.terraform.d/plugin-cache
             echo 'export TF_IN_AUTOMATION=true' >> $BASH_ENV
             echo 'export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache' >> $BASH_ENV
@@ -357,12 +366,13 @@ commands:
             time terraform plan -input=false
             time terraform apply -input=false -auto-approve
       - run:
-          name: Store Artifacts
+          name: Output JSON to screen
           command: |
             cd faas
             mkdir ~/project/tf-states-artifacts
             terraform state pull > ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json
             cat ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json | jq
+
 jobs:
   publish-aws-lambdas:
     executor: vpn/aws

--- a/microservices.yml
+++ b/microservices.yml
@@ -348,7 +348,7 @@ commands:
           command: |
             for lambdaDir in $LAMBDA_DIRECTORIES; do
               cd $lambdaDir/src
-              if [ -e package.json ]
+              if [[ -e package.json && -e package-lock.json ]]
               then
                 npm ci
               fi

--- a/microservices.yml
+++ b/microservices.yml
@@ -293,6 +293,7 @@ commands:
           name: Populate environment variables reused across lambda steps
           command: |
             echo 'export TF_IN_AUTOMATION=true' >> $BASH_ENV
+            echo 'export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache'
             echo 'export LAMBDA_DIRECTORIES=$(find ./faas/ -mindepth 1 -maxdepth 1 -type d)' >> $BASH_ENV
       - run:
           name: Map service configuration to terraform tfvar files

--- a/microservices.yml
+++ b/microservices.yml
@@ -263,14 +263,133 @@ commands:
             "prod")
                 echo "Using prod resources"
                 echo "export SVC_CONFIG_S3_BUCKET=mgmri-mobapp-production/services-configurations" >> $BASH_ENV
+                echo 'export TERRAFORM_STATE_S3_BUCKET=mgmri-services-tf-state' >> $BASH_ENV
                 ;;
             *)
                 echo "Using non-prod resources"
                 echo "export SVC_CONFIG_S3_BUCKET=mgmresorts-services-configurations" >> $BASH_ENV
+                echo 'export TERRAFORM_STATE_S3_BUCKET=mgmresorts-services-tf-state' >> $BASH_ENV
                 ;;
             esac
 
+  install-terraform-and-npm:
+    description: Install terraform and update npm (for npm ci)
+    steps:
+      - run:
+          name: Install terraform and update npm
+          command: |
+            npm i -g npm@latest
+
+            wget https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip
+            unzip terraform_0.11.13_linux_amd64.zip
+            sudo mv terraform /usr/local/bin/
+            terraform --version
+            rm *
+
+  setup-each-lambda-env:
+    description: Setup each lambda directory with env, aws, and npm deps
+    steps:
+      - run:
+          name: Populate environment variables reused across lambda steps
+          command: |
+            echo 'export TF_IN_AUTOMATION=true' >> $BASH_ENV
+            echo 'export LAMBDA_DIRECTORIES=$(find ./faas/ -mindepth 1 -maxdepth 1 -type d)' >> $BASH_ENV
+      - run:
+          name: Map service configuration to terraform tfvar files
+          command: |
+            # manually re-populate env vars due to inconsistent behavior
+            . $BASH_ENV
+
+            # create terraform.tfvars with all project config values so TF defs can access them
+            # this file is auto-loaded by terraform
+            cp build-workspace/environment/config.json terraform.tfvars.json
+
+            # create tf var declarations for circleci configuration variables
+            for s in $(cat build-workspace/environment/config.json | jq -r "keys[]" ); do
+              echo "variable \"$s\" {
+              type = \"string\"
+            }" >> circleci-config-vars.tf
+            done
+
+            for lambdaDir in $LAMBDA_DIRECTORIES; do
+              cp terraform.tfvars.json $lambdaDir
+              cp circleci-config-vars.tf $lambdaDir
+            done
+      - run:
+          name: Configure Terraform for aws tfState s3 bucket and okta-generated aws profile
+          command: |
+            for lambdaDir in $LAMBDA_DIRECTORIES; do
+              # 1. get function name from main.tf => aws_lambda_function => function_name property
+              export LAMBDA_NAME=$(cat $lambdaDir/main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//' | envsubst | sed -e 's/^"//' -e 's/"$//')
+
+              # 2. write template
+              echo '
+              # store TG State in S3
+              # Terraform block cannot use string interpolation
+              # envsubst is used instead (inline variables)
+              terraform {
+                backend "s3" {
+                  bucket  = "${TERRAFORM_STATE_S3_BUCKET}"
+                  key     = "${NODE_ENV}/${CIRCLE_PROJECT_REPONAME}/lambdas/${LAMBDA_NAME}.json"
+                  region  = "${AWS_DEFAULT_REGION}"
+                  profile = "${AWS_DEFAULT_PROFILE}"
+                }
+              }
+
+              # use okta-generated aws profile (session)
+              provider "aws" {
+                region  = "${AWS_DEFAULT_REGION}"
+                profile = "${AWS_DEFAULT_PROFILE}"
+              }' | envsubst > $lambdaDir/aws-backends.tf
+
+            done
+      - run:
+          name: Install npm dependencies if package.json exists
+          command: |
+            for lambdaDir in $LAMBDA_DIRECTORIES; do
+              cd $lambdaDir/src
+              if [ -e package.json ]
+              then
+                npm ci
+              fi
+              cd -
+            done
+
+  publish-each-lambda:
+    description: Publish each lambda and store tfState as artifact
+    steps:
+      - run:
+          name: Publish any lambda changes to aws
+          command: |
+            mkdir tf-states-artifacts
+
+            for lambdaDir in $LAMBDA_DIRECTORIES; do
+              cd $lambdaDir
+
+              terraform init -input=false
+              terraform plan -input=false
+              terraform apply -input=false -auto-approve
+
+              LAMBDA_NAME=$(cat main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//' | envsubst | sed -e 's/^"//' -e 's/"$//')
+              terraform state pull > ~/project/tf-states-artifacts/$LAMBDA_NAME.json
+
+              cd -
+            done
+      - store_artifacts:
+          path: ./tf-states-artifacts
+
 jobs:
+  publish-aws-lambdas:
+    executor: vpn/aws
+    steps:
+      - install-terraform-and-npm
+      - set-aws-account-specific-resources
+      - checkout
+      - populate-okta-cli
+      - populate-env-vars-into-job
+      - setup-each-lambda-env
+      - publish-each-lambda
+
   npm-audit:
     docker:
       - image: circleci/node:8

--- a/microservices.yml
+++ b/microservices.yml
@@ -305,35 +305,25 @@ commands:
 
             # create terraform.tfvars with all project config values so TF defs can access them
             # this file is auto-loaded by terraform
-            cp build-workspace/environment/config.json terraform.tfvars.json
+            cp build-workspace/environment/config.json faas/terraform.tfvars.json
 
             # create tf var declarations for circleci configuration variables
             for s in $(cat build-workspace/environment/config.json | jq -r "keys[]" ); do
               echo "variable \"$s\" {
               type = \"string\"
-            }" >> circleci-config-vars.tf
-            done
-
-            for lambdaDir in $LAMBDA_DIRECTORIES; do
-              cp terraform.tfvars.json $lambdaDir
-              cp circleci-config-vars.tf $lambdaDir
+            }" >> faas/circleci-config-vars.tf
             done
       - run:
           name: Configure Terraform for aws tfState s3 bucket and okta-generated aws profile
           command: |
-            for lambdaDir in $LAMBDA_DIRECTORIES; do
-              # 1. get function name from main.tf => aws_lambda_function => function_name property
-              export LAMBDA_NAME=$(cat $lambdaDir/main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//g' | envsubst | sed -e 's/^"//' -e 's/"$//')
-
-              # 2. write template
-              echo '
+            echo '
               # store TG State in S3
               # Terraform block cannot use string interpolation
               # envsubst is used instead (inline variables)
               terraform {
                 backend "s3" {
-                  bucket  = "${TERRAFORM_STATE_S3_BUCKET}"
-                  key     = "${NODE_ENV}/${CIRCLE_PROJECT_REPONAME}/lambdas/${LAMBDA_NAME}.json"
+                  bucket  = "${S3_BUCKET}"
+                  key     = "${NODE_ENV}/${CIRCLE_PROJECT_REPONAME}.json"
                   region  = "${AWS_DEFAULT_REGION}"
                   profile = "${AWS_DEFAULT_PROFILE}"
                 }
@@ -343,9 +333,7 @@ commands:
               provider "aws" {
                 region  = "${AWS_DEFAULT_REGION}"
                 profile = "${AWS_DEFAULT_PROFILE}"
-              }' | envsubst > $lambdaDir/aws-backends.tf
-
-            done
+              }' | envsubst > faas/aws-backend.tf
       - run:
           name: Install npm dependencies if package.json exists
           command: |
@@ -364,23 +352,17 @@ commands:
       - run:
           name: Publish any lambda changes to aws
           command: |
-            mkdir tf-states-artifacts
-
-            for lambdaDir in $LAMBDA_DIRECTORIES; do
-              cd $lambdaDir
-
-              terraform init -input=false
-              terraform plan -input=false
-              terraform apply -input=false -auto-approve
-
-              LAMBDA_NAME=$(cat main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//g' | envsubst | sed -e 's/^"//' -e 's/"$//')
-              terraform state pull > ~/project/tf-states-artifacts/$LAMBDA_NAME.json
-
-              cd -
-            done
-      - store_artifacts:
-          path: ./tf-states-artifacts
-
+            cd faas
+            time terraform init -input=false
+            time terraform plan -input=false
+            time terraform apply -input=false -auto-approve
+      - run:
+          name: Store Artifacts
+          command: |
+            cd faas
+            mkdir ~/project/tf-states-artifacts
+            terraform state pull > ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json
+            cat ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json | jq
 jobs:
   publish-aws-lambdas:
     executor: vpn/aws

--- a/microservices.yml
+++ b/microservices.yml
@@ -320,7 +320,7 @@ commands:
           command: |
             for lambdaDir in $LAMBDA_DIRECTORIES; do
               # 1. get function name from main.tf => aws_lambda_function => function_name property
-              export LAMBDA_NAME=$(cat $lambdaDir/main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//' | envsubst | sed -e 's/^"//' -e 's/"$//')
+              export LAMBDA_NAME=$(cat $lambdaDir/main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//g' | envsubst | sed -e 's/^"//' -e 's/"$//')
 
               # 2. write template
               echo '
@@ -370,7 +370,7 @@ commands:
               terraform plan -input=false
               terraform apply -input=false -auto-approve
 
-              LAMBDA_NAME=$(cat main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//' | envsubst | sed -e 's/^"//' -e 's/"$//')
+              LAMBDA_NAME=$(cat main.tf | grep -A 5 'resource "aws_lambda_function"' | grep function_name | awk '{print $3}' | sed 's/var\.//g' | envsubst | sed -e 's/^"//' -e 's/"$//')
               terraform state pull > ~/project/tf-states-artifacts/$LAMBDA_NAME.json
 
               cd -


### PR DESCRIPTION
# PR Details

## Existing behavior
CircleCI configuration does not include commands and jobs necessary to enable publishing of lambdas.

## New intended behavior
1. Adds necessary CircleCI configuration to enable publishing of lambdas. 
   - Please note this only publishes AWS Lambdas. API Gateway integration will be a separate update in `api` repo.
2. Adds instructions on how to utilize the `publish-aws-lambdas` job in CircleCI configuration with each of the microservice repos.

You can see this branch of accounts service for a working example with these changes: 
https://github.com/MGMResorts/accounts/tree/testOrb

CircleCI running `publish-aws-lambdas` job for that branch:
https://circleci.com/gh/MGMResorts/accounts/2706

## Where should a reviewer start?
README updates.

## Related Issue/Story
SRV-364

## Checklist
- [x] Performed a self-review.
- [x] Assigned reviewers and set myself as Assignee
- [x] Changed a documentation ([ x ] `[ x ]` if not required).
- [x] I have added tests ([ x ] `[ x ]` if no required).
