### PR TITLE
F/SRV-390 - Add Change Control CI Notification Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ workflows:
   build_and_test:
     jobs:
       - ms/setup-env:
-          context: microservices
+          context: microservices-okta
           filters:
             tags:
               only: /^v.*/
       - ms/build-image:
-          context: microservices
+          context: microservices-okta
           requires:
             - ms/setup-env
           filters:
             tags:
               only: /^v.*/
       - ms/push-image:
-          context: microservices
+          context: microservices-okta
           requires:
             - ms/build-image
             - ms/run-unit-tests
@@ -46,14 +46,14 @@ workflows:
             tags:
               only: /^v.*/
       - ms/run-unit-tests:
-          context: microservices
+          context: microservices-okta
           requires:
             - ms/build-image
           filters:
             tags:
               only: /^v.*/
       - ms/run-integration-tests:
-          context: microservices
+          context: microservices-okta
           requires:
             - ms/build-image
           filters:
@@ -67,16 +67,25 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - hold:
-          type: approval
+      - ms/change-management-event:
+          context: microservices-okta
           requires:
             - ms/push-image
           filters:
             branches:
               only:
                 - prod
+      - hold:
+          type: approval
+          requires:
+            - ms/change-management-event
+            - ms/push-image
+          filters:
+            branches:
+              only:
+                - prod
       - ms/deploy-svc:
-          context: microservices
+          context: microservices-okta
           requires:
             - hold
             - ms/push-image

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - ms/change-management-event:
+      - ms/prod-change-management-event:
           context: microservices-okta
           requires:
             - ms/push-image
@@ -78,7 +78,7 @@ workflows:
       - hold:
           type: approval
           requires:
-            - ms/change-management-event
+            - ms/prod-change-management-event
             - ms/push-image
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -67,28 +67,29 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - ms/prod-change-management-event:
-          context: microservices-okta
-          requires:
-            - ms/push-image
-          filters:
-            branches:
-              only:
-                - prod
       - hold:
           type: approval
           requires:
-            - ms/prod-change-management-event
             - ms/push-image
           filters:
             branches:
               only:
                 - prod
+      - ms/change-management-event:
+          context: microservices-okta
+          requires:
+            - hold
+          filters:
+            branches:
+              only:
+                - preprod
+                - /^prod-.*/
       - ms/deploy-svc:
           context: microservices-okta
           requires:
             - hold
             - ms/push-image
+            - ms/change-management-event
       - ms/publish-aws-lambdas:
           context: microservices-okta
           requires:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Orb depends on each service to implement `build tag export-image push-image
 version: 2.1
 
 orbs:
-  ms: mgmorbs/microservices@1
+  ms: mgmorbs/microservices@2
 
 workflows:
   version: 2

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,46 @@
+/**
+ * @name Production PR Dangerfile
+ *
+ * @description
+ * This dangerfile validates production PRs before the deployment step
+ * to assure all change order requirements are met.
+ * The data captured here is then forwarded to Azure.
+ *
+ * See the following orb commands for reference:
+ * validate-change-management-event-info
+ * send-change-management-event
+ */
+const { danger, warn, message } = require('danger');
+const { checkAssignees } = require('danger-plugin-complete-pr');
+// const deploymentSummarySectionTitle = '# Production Deployment Summary';
+const deploymentSummarySectionTitle = '## Checklist';
+const prodChangeEvent = {
+  requestor: null,
+  templateId: null,
+  affectedEndUser: null,
+  assignee: 'MGMResorts/prod-deployment-approvers',
+  scheduledStartDate: new Date(),
+};
+
+// Requestor Field
+checkAssignees();
+prodChangeEvent.requestor = danger.github.pr.assignee.login;
+
+// Deployment Summary
+checkDeploymentSummary();
+
+function checkDeploymentSummary() {
+  if (danger.github.pr.base.ref !== 'prod') return;
+
+  const hasDeploymentSummarySection = danger.github.pr.body.includes(deploymentSummarySectionTitle)
+  const hasDeploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle).length
+    && danger.github.pr.body.split(deploymentSummarySectionTitle)[1].length > 7
+
+  if (!hasDeploymentSummarySection || !hasDeploymentSummaryText) {
+    fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.');
+  } else {
+    prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1];
+    message(`Azure change management system event: ${JSON.stringify(prodChangeEvent)}`);
+  }
+}
+

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -60,8 +60,6 @@ const githubFormatJson = msgObj => `\n \`\`\`js \n ${JSON.stringify(msgObj, null
 checkAssignees()
 prodChangeEvent.requestor = danger.github.pr.assignee.login
 
-console.log('Checking Deployment Summary');
-
 // Capture Deployment Summary
 if(hasDeploymentSummary()) {
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -38,10 +38,7 @@ function checkDeploymentSummary() {
     fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.');
   } else {
     prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1];
-    message(
-      `Azure change management system event: 
-      \`\`\`\n ${JSON.stringify(prodChangeEvent, null, 2)} \`\`\` `
-    );
+    message(`Azure change management system event: \n \`\`\`js ${JSON.stringify(prodChangeEvent, null, 2)} \n \`\`\` `);
   }
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -6,39 +6,54 @@
  * to assure all change order requirements are met.
  * The data captured here is then forwarded to Azure.
  *
- * See the following orb commands for reference:
- * validate-change-management-event-info
- * send-change-management-event
+ * See the orb commands for reference:
  */
-const { danger, warn, message } = require('danger');
-const { checkAssignees } = require('danger-plugin-complete-pr');
-// const deploymentSummarySectionTitle = '# Production Deployment Summary';
-const deploymentSummarySectionTitle = '## Checklist';
+const { checkAssignees } = require('danger-plugin-complete-pr')
+const { EventHubClient, EventPosition } = require('@azure/event-hubs')
+const client = EventHubClient.createFromConnectionString(process.env["EVENTHUB_CONNECTION_STRING"], process.env["EVENTHUB_NAME"])
+const deploymentSummarySectionTitle = '# Production Deployment Summary'
 const prodChangeEvent = {
   requestor: null,
   templateId: null,
   affectedEndUser: null,
   assignee: 'MGMResorts/prod-deployment-approvers',
   scheduledStartDate: new Date(),
-};
-
-// Requestor Field
-checkAssignees();
-prodChangeEvent.requestor = danger.github.pr.assignee.login;
-
-// Deployment Summary
-checkDeploymentSummary();
-
-function checkDeploymentSummary() {
-  const hasDeploymentSummarySection = danger.github.pr.body.includes(deploymentSummarySectionTitle)
-  const hasDeploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle).length
-    && danger.github.pr.body.split(deploymentSummarySectionTitle)[1].length > 7
-
-  if (!hasDeploymentSummarySection || !hasDeploymentSummaryText) {
-    fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.');
-  } else {
-    prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1];
-    message(`Azure change management system event: \n \`\`\`js \n ${JSON.stringify(prodChangeEvent, null, 2)} \n \`\`\` `);
-  }
 }
 
+/**
+ * Checks for a specific section of
+ * the PR description called prod deployment summary
+ *
+ * @return {Boolean}
+ */
+const hasDeploymentSummary = () => {
+  const hasDeploymentSummarySection = danger.github.pr.body.includes(deploymentSummarySectionTitle)
+  const hasDeploymentSummaryText = hasDeploymentSummarySection &&
+    danger.github.pr.body.split(deploymentSummarySectionTitle).length &&
+    danger.github.pr.body.split(deploymentSummarySectionTitle)[1].length > 7
+
+  return hasDeploymentSummaryText
+}
+
+/**
+ * Send event to Azure Event Hub.
+ * Will also post a Danger message with the event info.
+ * @param  {Object} prodChangeEvent
+ * @return {undefined}
+ */
+async function sendEventToAzureEventHub(prodChangeEvent){
+  await client.send(prodChangeEvent)
+  message(`Azure change management system event: \n \`\`\`js \n ${JSON.stringify(prodChangeEvent, null, 2)} \n \`\`\` `)
+}
+
+// Requestor Field
+checkAssignees()
+prodChangeEvent.requestor = danger.github.pr.assignee.login
+
+// Deployment Summary
+if(hasDeploymentSummary()) {
+  prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1]
+  sendEventToAzureEventHub(prodChangeEvent)
+} else {
+  fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.')
+}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -30,8 +30,6 @@ prodChangeEvent.requestor = danger.github.pr.assignee.login;
 checkDeploymentSummary();
 
 function checkDeploymentSummary() {
-  if (danger.github.pr.base.ref !== 'prod') return;
-
   const hasDeploymentSummarySection = danger.github.pr.body.includes(deploymentSummarySectionTitle)
   const hasDeploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle).length
     && danger.github.pr.body.split(deploymentSummarySectionTitle)[1].length > 7

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -38,7 +38,10 @@ function checkDeploymentSummary() {
     fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.');
   } else {
     prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1];
-    message(`Azure change management system event: ${JSON.stringify(prodChangeEvent)}`);
+    message(
+      `Azure change management system event: 
+      \`\`\`\n ${JSON.stringify(prodChangeEvent, null, 2)} \`\`\` `
+    );
   }
 }
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -69,7 +69,7 @@ if(hasDeploymentSummary()) {
 
   sendEventToChangeMgmtSystem(prodChangeEvent)
     .then(r =>
-      message(`MGM Change Management system event sent. ${githubFormatJson(prodChangeEvent)}`)
+      message(`All production-dangerfile checks passed. A production change event has been sent to MGM Change Management system. ${githubFormatJson(prodChangeEvent)}`)
     )
     .catch(azureError =>
       fail(`Unable to send Change Management event to Azure. ${githubFormatJson(azureError)}`)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -38,7 +38,7 @@ function checkDeploymentSummary() {
     fail('Deployment Summary section is missing. Add "# Production Deployment Summary" to the end of the PR description followed by changes in this deployment.');
   } else {
     prodChangeEvent.deploymentSummaryText = danger.github.pr.body.split(deploymentSummarySectionTitle)[1];
-    message(`Azure change management system event: \n \`\`\`js ${JSON.stringify(prodChangeEvent, null, 2)} \n \`\`\` `);
+    message(`Azure change management system event: \n \`\`\`js \n ${JSON.stringify(prodChangeEvent, null, 2)} \n \`\`\` `);
   }
 }
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -380,21 +380,15 @@ commands:
           name: Install danger locally and fetch prod PR dangerfile
           command: |
             # install danger
-            npm i danger
-            npm i danger-plugin-complete-pr
+            npm i danger danger-plugin-complete-pr @azure/event-hubs
 
             # get dangerfile
             wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O dangerfile.js
       - run:
-          name: Run danger for Prod PR
+          name: Run danger for Prod PR to validate required change-request fields and send event to Azure
           command: |
             # run dangerfile
             ./node_modules/.bin/danger ci
-      - run:
-          name: Send event to Azure
-          command: |
-            # TO DO: send azure event
-
 
 jobs:
   publish-aws-lambdas:

--- a/microservices.yml
+++ b/microservices.yml
@@ -381,6 +381,7 @@ commands:
           command: |
             # install danger
             npm i danger
+            npm i danger-plugin-complete-pr
 
             # get dangerfile
             wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O dangerfile.js

--- a/microservices.yml
+++ b/microservices.yml
@@ -383,7 +383,7 @@ commands:
             npm i danger
 
             # get dangerfile
-            wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O test-dangerfile.js
+            wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O dangerfile.js
       - run:
           name: Run danger for Prod PR
           command: |

--- a/microservices.yml
+++ b/microservices.yml
@@ -380,7 +380,7 @@ commands:
           name: Install danger locally and fetch prod PR dangerfile
           command: |
             # install danger
-            npm i danger danger-plugin-complete-pr @azure/event-hubs
+            npm i danger danger-plugin-complete-pr axios @azure/event-hubs
 
             # get dangerfile
             wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O dangerfile.js

--- a/microservices.yml
+++ b/microservices.yml
@@ -388,7 +388,7 @@ commands:
           name: Run danger for Prod PR to validate required change-request fields and send event to Azure
           command: |
             # run dangerfile
-            ./node_modules/.bin/danger ci
+            ./node_modules/.bin/danger ci --failOnErrors
 
 jobs:
   publish-aws-lambdas:

--- a/microservices.yml
+++ b/microservices.yml
@@ -373,6 +373,31 @@ commands:
             terraform state pull > ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json
             cat ~/project/tf-states-artifacts/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.json | jq
 
+  prod-change-management-event:
+    description: Trigger an event to be published to change management system of record in Azure
+    steps:
+      - run:
+          name: Install danger locally and fetch prod PR dangerfile
+          command: |
+            # install danger
+            npm i danger
+
+            # get dangerfile
+            wget https://api.github.com/repos/MGMResorts/microservices/contents/prod-dangerfile.js \
+              --header="Authorization: token $MAKEFILE_GITHUB_TOKEN" \
+              --header="Accept: application/vnd.github.v3.raw" \
+              -O dangerfile.js
+      - run:
+          name: Run danger for Prod PR
+          command: |
+            # run dangerfile
+            ./node_modules/.bin/danger ci
+      - run:
+          name: Send event to Azure
+          command: |
+            # TO DO: send azure event
+
+
 jobs:
   publish-aws-lambdas:
     executor: vpn/aws
@@ -458,6 +483,13 @@ jobs:
     steps:
       - checkout
       - run-lint
+
+  # Step 5 pre-req for prod only
+  change-management-event:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - prod-change-management-event
 
   # Step 5: Deploys build image to ECS by registring task and updating cluster
   deploy-svc:

--- a/microservices.yml
+++ b/microservices.yml
@@ -383,10 +383,7 @@ commands:
             npm i danger
 
             # get dangerfile
-            wget https://api.github.com/repos/MGMResorts/microservices/contents/prod-dangerfile.js \
-              --header="Authorization: token $MAKEFILE_GITHUB_TOKEN" \
-              --header="Accept: application/vnd.github.v3.raw" \
-              -O dangerfile.js
+            wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/SRV-390/dangerfile.js -O test-dangerfile.js
       - run:
           name: Run danger for Prod PR
           command: |


### PR DESCRIPTION
### New Behavior
`change-management-event` job is added to notify EventHub and an Azure Function for production deployments.

This job:
* gathers information from the Pull Request (via danger.js) 
* sends payload to EventHub
* sends payload to Azure Function
* posts the same payload on the PR itself (via danger.js)

New keys required in `microservices-okta` context: 
* `PROD_CHANGE_ORDER_FUNC_URL`
* `PROD_CHANGE_ORDER_EVENTHUB_CONNECTION_STRING`
* `PROD_CHANGE_ORDER_EVENTHUB_NAME`

### Usage
Current MS circleci configs should be updated to add `change-management-event` job before the `deploy` job and filtered to `prod` branch only.

### Jira
https://mgmdigitalventures.atlassian.net/browse/SRV-390