### PR TITLE
manually load bash env since env vars were not present

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -153,6 +153,7 @@ commands:
       - run:
           name: Deploy New Task Definition to ECS Cluster
           command: |
+            . $BASH_ENV
             make deploy
 
   install-okta-aws-cli:

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.0"
+  "version": "2.2.1"
 }


### PR DESCRIPTION
### Existing Behavior
Currently, ms-util-cli's deploy command failed due to $SERVICE env var being unavailable.

### New Intended Behavior
Before the deployment step, all env variables in the $BASH_ENV will be manually loaded.


This is part of versioning rollout effort.