### PR TITLE
F/publish swagger def after deploy

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -168,6 +168,7 @@ commands:
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |
+            echo "Swagger spec being sent to S3 ($SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json)
             aws s3 cp ./swagger.json s3://$SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json
       - store_artifacts:
           path: ./swagger.json

--- a/microservices.yml
+++ b/microservices.yml
@@ -552,4 +552,5 @@ jobs:
       - checkout
       - populate-env-vars-into-job
       - populate-okta-cli
+      - populate-test-configs-from-workspace
       - publish-swagger-to-s3-for-tag

--- a/microservices.yml
+++ b/microservices.yml
@@ -168,7 +168,7 @@ commands:
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |
-            echo "Swagger spec being sent to S3 ($SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json)
+            echo "Swagger spec being sent to S3 ($SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json)"
             aws s3 cp ./swagger.json s3://$SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json
       - store_artifacts:
           path: ./swagger.json

--- a/microservices.yml
+++ b/microservices.yml
@@ -156,6 +156,22 @@ commands:
             . $BASH_ENV
             make deploy
 
+  publish-swagger-to-s3-for-tag:
+    description: Publish the API Open API spec (swagger doc) to S3 for API updates
+    steps:
+      - run:
+          name: Run documentation npm script
+          command: |
+            . $BASH_ENV
+            npm i
+            docker-compose up --build document
+      - run:
+          name: publish to s3 bucket under $service/$semantic_tag.json pattern
+          command: |
+            aws cp ./swagger.json s3://$SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json
+      - store_artifacts:
+          path: ./swagger.json
+
   install-okta-aws-cli:
     description: Install Okta Assume Role Client and tooling
     steps:
@@ -188,7 +204,7 @@ commands:
                 OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_PROD_ROLE_TO_ASSUME
                 ;;
             *)
-                echo "Using NON-prod Config - $OKTA_AWS_PROD_ROLE_TO_ASSUME"
+                echo "Using NON-prod Config - $OKTA_AWS_NONPROD_ROLE_TO_ASSUME"
                 OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_NONPROD_ROLE_TO_ASSUME
                 ;;
             esac
@@ -265,11 +281,13 @@ commands:
                 echo "Using prod resources"
                 echo "export SVC_CONFIG_S3_BUCKET=mgmri-mobapp-production/services-configurations" >> $BASH_ENV
                 echo 'export TERRAFORM_STATE_S3_BUCKET=mgmri-services-tf-state' >> $BASH_ENV
+                echo 'export SWAGGER_BUCKET=mgmri-services-swagger-specs' >> $BASH_ENV
                 ;;
             *)
                 echo "Using non-prod resources"
                 echo "export SVC_CONFIG_S3_BUCKET=mgmresorts-services-configurations" >> $BASH_ENV
                 echo 'export TERRAFORM_STATE_S3_BUCKET=mgmresorts-services-tf-state' >> $BASH_ENV
+                echo 'export SWAGGER_BUCKET=mgmresorts-services-swagger-specs' >> $BASH_ENV
                 ;;
             esac
 
@@ -406,12 +424,6 @@ commands:
           command: |
             # run script to push results to Jira
             bash /home/circleci/project/push-test-results-to-xray.sh ./reports/unit-test-mocha-results.xml SRV junit
-      # - run:
-      #     name: Upload Cucumber unit test results to Jira Xray
-      #     when: always
-      #     command: |
-      #       # run script to push results to Jira
-      #       bash /home/circleci/project/push-test-results-to-xray.sh ./reports/unit-test-results.json SRV cucumber
 
   publish-integration-test-results-to-xray:
     description: Publish all integration test results to Jira Xray
@@ -428,13 +440,6 @@ commands:
           command: |
             # run script to push results to Jira
             bash /home/circleci/project/push-test-results-to-xray.sh ./reports/integration-test-mocha-results.xml SRV junit
-
-      # - run:
-      #     name: Upload Cucumber integration test results to Jira Xray
-      #     when: always
-      #     command: |
-      #       # run script to push results to Jira
-      #       bash /home/circleci/project/push-test-results-to-xray.sh ./reports/integration-test-results.json SRV cucumber
 
 jobs:
   publish-aws-lambdas:
@@ -540,3 +545,11 @@ jobs:
       - populate-okta-cli
       - populate-secret-ssm-env-vars
       - deploy
+
+  publish-swagger:
+    executor: vpn/aws
+    steps:
+      - checkout
+      - populate-env-vars-into-job
+      - populate-okta-cli
+      - publish-swagger-to-s3-for-tag

--- a/microservices.yml
+++ b/microservices.yml
@@ -552,6 +552,7 @@ jobs:
     steps:
       - checkout
       - populate-env-vars-into-job
+      - set-aws-account-specific-resources
       - populate-okta-cli
       - populate-test-configs-from-workspace
       - publish-swagger-to-s3-for-tag

--- a/microservices.yml
+++ b/microservices.yml
@@ -164,7 +164,7 @@ commands:
           command: |
             . $BASH_ENV
             npm i
-            docker-compose up --build document
+            npm run document
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |

--- a/microservices.yml
+++ b/microservices.yml
@@ -168,7 +168,7 @@ commands:
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |
-            aws cp ./swagger.json s3://$SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json
+            aws s3 cp ./swagger.json s3://$SWAGGER_BUCKET/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG.json
       - store_artifacts:
           path: ./swagger.json
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -164,7 +164,7 @@ commands:
           command: |
             . $BASH_ENV
             npm i
-            npm run document
+            docker-compose up --build document
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.5"
+  "version": "2.2.6"
 }


### PR DESCRIPTION
New job called `push-swagger` is now added.

It can be used like to generate swagger spec and publish it to an s3 bucket specifically for that purpose.

Working example: https://circleci.com/workflow-run/94a2f012-ea06-483d-b101-1d62266041ad
![Screenshot from 2019-07-17 18-17-03](https://user-images.githubusercontent.com/43968998/61418123-1c634b00-a8bf-11e9-9fcb-ffcb0b68d5dd.png)
