### PR TITLE
F/SRV-1119: Support publishing ecr images to prod aws account

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - ms/push-image-prod:
+          context: microservices-okta
+          requires:
+            - ms/build-image
+          filters:
+            tags:
+              only: /^v.*/
+          branches:
+            ignore: /.*/
       - ms/push-image:
           context: microservices-okta
           requires:

--- a/microservices.yml
+++ b/microservices.yml
@@ -91,7 +91,7 @@ commands:
             echo "export CIRCLE_BRANCH=prod" >> $BASH_ENV
             . $BASH_ENV
             echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to force-switch okta cli to production aws account"
-            rm -r ~/.okta
+            rm -rf ~/.okta
       - install-okta-aws-cli
       - run:
           name: Push Image to production ECR

--- a/microservices.yml
+++ b/microservices.yml
@@ -85,6 +85,8 @@ commands:
           command: |
             echo "export ORIGINAL_CIRCLE_BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
             echo "export CIRCLE_BRANCH=prod" >> $BASH_ENV
+            echo "export ECR_APP_IMAGE_ORIGINAL=$ECR_APP_IMAGE" >> $BASH_ENV
+            echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/devices" >> $BASH_ENV
             . $BASH_ENV
             echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to force-switch okta cli to production aws account"
             rm -r ~/.okta
@@ -97,6 +99,7 @@ commands:
           name: Reset CircleCI branch env var
           command: |
             echo "export CIRCLE_BRANCH=$ORIGINAL_CIRCLE_BRANCH" >> $BASH_ENV
+            echo "export ECR_APP_IMAGE=$ECR_APP_IMAGE_ORIGINAL" >> $BASH_ENV
             . $BASH_ENV
             echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to switch okta cli back to non-prod aws account"
             rm -r ~/.okta

--- a/microservices.yml
+++ b/microservices.yml
@@ -80,6 +80,7 @@ commands:
           name: Push Image to ECR
           command: |
             make push-image-to-ecr
+
   push-built-image-to-prod-ecr:
     description: Publish docker image to production ECR
     steps:
@@ -523,6 +524,14 @@ jobs:
       - populate-okta-cli
       - attach-built-docker-image
       - push-built-image-to-ecr
+
+  push-image-prod:
+    executor: vpn/aws
+    steps:
+      - checkout
+      - populate-env-vars-into-job
+      - attach-built-docker-image
+      - push-built-image-to-prod-ecr
 
   # Step 3a: Verify that unit tests are passing
   run-unit-tests:

--- a/microservices.yml
+++ b/microservices.yml
@@ -80,6 +80,9 @@ commands:
           name: Push Image to ECR
           command: |
             make push-image-to-ecr
+  push-built-image-to-prod-ecr:
+    description: Publish docker image to production ECR
+    steps:
       - run:
           name: Switch to PRODUCTION aws account
           command: |
@@ -95,8 +98,7 @@ commands:
             echo "export ECR_APP_IMAGE_ORIGINAL=$ECR_APP_IMAGE" >> $BASH_ENV
             echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/devices" >> $BASH_ENV
             . $BASH_ENV
-            make build tag
-            make push-image-to-ecr
+            make build tag push-image-to-ecr
       - run:
           name: Reset CircleCI branch env var
           command: |

--- a/microservices.yml
+++ b/microservices.yml
@@ -85,8 +85,6 @@ commands:
           command: |
             echo "export ORIGINAL_CIRCLE_BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
             echo "export CIRCLE_BRANCH=prod" >> $BASH_ENV
-            echo "export ECR_APP_IMAGE_ORIGINAL=$ECR_APP_IMAGE" >> $BASH_ENV
-            echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/devices" >> $BASH_ENV
             . $BASH_ENV
             echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to force-switch okta cli to production aws account"
             rm -r ~/.okta
@@ -94,6 +92,10 @@ commands:
       - run:
           name: Push Image to production ECR
           command: |
+            echo "export ECR_APP_IMAGE_ORIGINAL=$ECR_APP_IMAGE" >> $BASH_ENV
+            echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/devices" >> $BASH_ENV
+            . $BASH_ENV
+            make build tag
             make push-image-to-ecr
       - run:
           name: Reset CircleCI branch env var
@@ -101,7 +103,7 @@ commands:
             echo "export CIRCLE_BRANCH=$ORIGINAL_CIRCLE_BRANCH" >> $BASH_ENV
             echo "export ECR_APP_IMAGE=$ECR_APP_IMAGE_ORIGINAL" >> $BASH_ENV
             . $BASH_ENV
-            echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to switch okta cli back to non-prod aws account"
+            echo "Manually revert CIRCLE_BRANCH to $CIRCLE_BRANCH and ECR_APP_IMAGE to $ECR_APP_IMAGE_ORIGINAL inorder to switch okta cli back to non-prod aws account"
             rm -r ~/.okta
       - install-okta-aws-cli
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -77,17 +77,30 @@ commands:
     description: Pushes built image to ECR based on environment variables
     steps:
       - run:
-          name: Push Image to non-prod ECR
+          name: Push Image to ECR
           command: |
             make push-image-to-ecr
-
-            # Delete Okta directory to switch to production aws account
+      - run:
+          name: Switch to PRODUCTION aws account
+          command: |
+            echo "export ORIGINAL_CIRCLE_BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
+            echo "export CIRCLE_BRANCH=prod" >> $BASH_ENV
+            . $BASH_ENV
+            echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to force-switch okta cli to production aws account"
             rm -r ~/.okta
-      - ms/install-okta-aws-cli
+      - install-okta-aws-cli
       - run:
           name: Push Image to production ECR
           command: |
             make push-image-to-ecr
+      - run:
+          name: Reset CircleCI branch env var
+          command: |
+            echo "export CIRCLE_BRANCH=$ORIGINAL_CIRCLE_BRANCH" >> $BASH_ENV
+            . $BASH_ENV
+            echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to switch okta cli back to non-prod aws account"
+            rm -r ~/.okta
+      - install-okta-aws-cli
 
   run-unit-tests-in-docker:
     description: Runs tests in docker container

--- a/microservices.yml
+++ b/microservices.yml
@@ -92,7 +92,7 @@ commands:
             rm -f ~/.okta/.current-session
             rm -f ~/.okta/profiles
 
-            cat ~/.okta/config.properties | sed -i "s~OKTA_AWS_ROLE_TO_ASSUME=.*~OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_PROD_ROLE_TO_ASSUME~g"
+            sed "s~OKTA_AWS_ROLE_TO_ASSUME=.*~OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_PROD_ROLE_TO_ASSUME~g" -i ~/.okta/config.properties
             java -jar ~/.okta/okta-aws-cli.jar sts get-caller-identity
       - run:
           name: Push Image to production ECR

--- a/microservices.yml
+++ b/microservices.yml
@@ -77,7 +77,15 @@ commands:
     description: Pushes built image to ECR based on environment variables
     steps:
       - run:
-          name: Push Image to ECR
+          name: Push Image to non-prod ECR
+          command: |
+            make push-image-to-ecr
+
+            # Delete Okta directory to switch to production aws account
+            rm -r ~/.okta
+      - ms/install-okta-aws-cli
+      - run:
+          name: Push Image to production ECR
           command: |
             make push-image-to-ecr
 

--- a/microservices.yml
+++ b/microservices.yml
@@ -84,29 +84,30 @@ commands:
   push-built-image-to-prod-ecr:
     description: Publish docker image to production ECR
     steps:
+      - install-okta-aws-cli
       - run:
           name: Switch to PRODUCTION aws account
           command: |
-            echo "export ORIGINAL_CIRCLE_BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
-            echo "export CIRCLE_BRANCH=prod" >> $BASH_ENV
-            . $BASH_ENV
-            echo "Manually set CIRCLE_BRANCH to $CIRCLE_BRANCH inorder to force-switch okta cli to production aws account"
-            rm -rf ~/.okta
-      - install-okta-aws-cli
+            rm -f ~/.okta/cookies.properties
+            rm -f ~/.okta/.current-session
+            rm -f ~/.okta/profiles
+
+            cat ~/.okta/config.properties | sed -i "s~OKTA_AWS_ROLE_TO_ASSUME=.*~OKTA_AWS_ROLE_TO_ASSUME=$OKTA_AWS_PROD_ROLE_TO_ASSUME~g"
+            java -jar ~/.okta/okta-aws-cli.jar sts get-caller-identity
       - run:
           name: Push Image to production ECR
           command: |
             echo "export ECR_APP_IMAGE_ORIGINAL=$ECR_APP_IMAGE" >> $BASH_ENV
             echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/devices" >> $BASH_ENV
+            echo "Manually set ECR_APP_IMAGE to $ECR_APP_IMAGE_ORIGINAL for prod aws account access"
             . $BASH_ENV
             make build tag push-image-to-ecr
       - run:
           name: Reset CircleCI branch env var
           command: |
-            echo "export CIRCLE_BRANCH=$ORIGINAL_CIRCLE_BRANCH" >> $BASH_ENV
             echo "export ECR_APP_IMAGE=$ECR_APP_IMAGE_ORIGINAL" >> $BASH_ENV
             . $BASH_ENV
-            echo "Manually revert CIRCLE_BRANCH to $CIRCLE_BRANCH and ECR_APP_IMAGE to $ECR_APP_IMAGE_ORIGINAL inorder to switch okta cli back to non-prod aws account"
+            echo "Manually revert ECR_APP_IMAGE to $ECR_APP_IMAGE_ORIGINAL inorder to switch okta cli back to non-prod aws account"
             rm -r ~/.okta
       - install-okta-aws-cli
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.6"
+  "version": "2.2.7"
 }


### PR DESCRIPTION
### Existing Behavior

ECR image is built and published to non-prod account when we tag services on `qa4` branch.

This leaves prod AWS account without the ECR image artifact when using version-based deployment

### New Intended Behavior

New `push-image-prod` job is now available. 
When used as noted in Readme, it will publish the docker image to `prod` ECR for version tagged builds.

### Working Example

See a working example for devices service here:
https://circleci.com/workflow-run/69438c86-db6a-435c-a24c-b9b2c7ab571f

![Screenshot from 2019-07-24 15-51-24](https://user-images.githubusercontent.com/43968998/61827761-ee37bb00-ae2a-11e9-9713-e45673dd62f4.png)

and published to prod ECR with version tag:

![Screenshot from 2019-07-24 15-50-48](https://user-images.githubusercontent.com/43968998/61827714-da8c5480-ae2a-11e9-8a5a-6594f187edba.png)
