### PR TITLE
Circleci unblock

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vpn: mgmorbs/vpn@dev:use_ubuntu_1604
+  vpn: mgmorbs/vpn@1
 
 commands:
   print-diagnostics:

--- a/microservices.yml
+++ b/microservices.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vpn: mgmorbs/vpn@0.1.0
+  vpn: mgmorbs/vpn@dev:use_ubuntu_1604
 
 commands:
   print-diagnostics:

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.7"
+  "version": "2.2.8"
 }


### PR DESCRIPTION
use newer executor (by the means of using newer `vpn` orb version) to be able to use `docker` buildkit and `ssh-agent` forwarding