### PR TITLE
build swagger form makefile

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -190,11 +190,10 @@ commands:
     description: Publish the API Open API spec (swagger doc) to S3 for API updates
     steps:
       - run:
-          name: Run documentation npm script
+          name: Run swagger.json creation
           command: |
             . $BASH_ENV
-            npm i
-            docker-compose up --build document
+            make swagger
       - run:
           name: publish to s3 bucket under $service/$semantic_tag.json pattern
           command: |

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.8"
+  "version": "2.2.9"
 }


### PR DESCRIPTION
we no longer use `docker-compose` as we need features from `docker` that are not supported by `docker-compose`

this pr changes the way we are generating `swagger.json` file by utilizing common Makefile instead of `docker-compose`