### PR TITLE
Hf/ssm params not loading

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -54,7 +54,7 @@ commands:
       - run:
           name: Populates secrets environment variables from SSM based on SSM_PATH_PREFIX in environment variables
           command: |
-            cat build-workspace/secrets.json | jq -r '.Parameters|map( (.Name | sub("'$SSM_PATH_PREFIX/'"; "") | gsub("[/-]"; "_")) + "=" + "\"" + .Value + "\"") | .[]' >> $BASH_ENV
+            cat build-workspace/secrets.json | jq -r '.Parameters|map( (.Name | sub("'$SSM_PATH_PREFIX/'"; "export ") | gsub("[/-]"; "_")) + "=" + "\"" + .Value + "\"") | .[]' >> $BASH_ENV
 
   build-and-tag-docker-image:
     description: Builds the docker image and tags it with commit and branch

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.12"
+  "version": "2.2.13"
 }


### PR DESCRIPTION
### Existing Behavior

SSM parameters are not loading into environment consistently. They are present but only evaluate after manually loading `$BASH_ENV`.

This causes empty SSM values for task definitions, causing faulty deployment phase.

### New Intended Behavior

When appending to `$BASH_ENV`, ssm parameter logic will append `export ` to assure that the variable is loaded permanently into the environment of the build.

Note: This is blocking SRV-2346 work for establishing automated deployment mechanism in circleci for versioned containers.