### PR TITLE
Feature/srv 2346

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,29 +76,28 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - ms/nonprod-deploy:
+          context: microservices-okta
+          requires:
+            - ms/push-image
+          filters: *ms-deployable-refs-filter
       - hold:
           type: approval
           requires:
             - ms/push-image
-          filters:
-            branches:
-              only:
-                - prod
+          filters: *ms-deployable-refs-filter
       - ms/change-management-event:
           context: microservices-okta
           requires:
             - hold
-          filters:
-            branches:
-              only:
-                - preprod
-                - /^prod-.*/
-      - ms/deploy-svc:
+          filters: *ms-deployable-refs-filter
+      - ms/prod-deploy:
           context: microservices-okta
           requires:
-            - hold
             - ms/push-image
+            - hold
             - ms/change-management-event
+          filters: *ms-deployable-refs-filter
       - ms/publish-aws-lambdas:
           context: microservices-okta
           requires:

--- a/microservices.yml
+++ b/microservices.yml
@@ -172,14 +172,31 @@ commands:
           root: .
           paths:
             - secrets.json
-  deploy:
-    description: Deploy task definition in ECR to ECS Service
+
+  deploy-to-nonprod:
+    description: Deploy task definition in ECR to ECS Service in qa4, uat, and preprod
     steps:
       - run:
           name: Deploy New Task Definition to ECS Cluster
           command: |
             . $BASH_ENV
-            make deploy
+            make deploy DEPLOY_ENV_NAME=qa4
+            make deploy DEPLOY_ENV_NAME=uat
+            make deploy DEPLOY_ENV_NAME=preprod
+
+  deploy-to-prod:
+    description: Deploy service to production
+    steps:
+      - run:
+          name: Deploy New Task Definition to ECS Cluster
+          command: |
+            export CIRCLE_BRANCH=prod
+      - set-aws-account-specific-resources
+      - run:
+          name: Deploy New Task Definition to ECS Cluster
+          command: |
+            . $BASH_ENV
+            make deploy DEPLOY_ENV_NAME=prod
 
   publish-swagger-to-s3-for-tag:
     description: Publish the API Open API spec (swagger doc) to S3 for API updates
@@ -578,6 +595,21 @@ jobs:
       - populate-env-vars-into-job
       - populate-okta-cli
       - deploy
+
+  nonprod-deploy:
+    executor: vpn/aws
+    steps:
+      - checkout
+      - set-aws-account-specific-resources
+      - populate-okta-cli
+      - deploy-to-nonprod
+
+ in qa4, uat, and preprod  prod-deploy:
+    executor: vpn/aws
+    steps:
+      - checkout
+      - populate-okta-cli
+      - deploy-to-prod
 
   publish-swagger:
     executor: vpn/aws

--- a/microservices.yml
+++ b/microservices.yml
@@ -604,7 +604,7 @@ jobs:
       - populate-okta-cli
       - deploy-to-nonprod
 
- in qa4, uat, and preprod  prod-deploy:
+  prod-deploy:
     executor: vpn/aws
     steps:
       - checkout

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.13"
+  "version": "2.2.14"
 }


### PR DESCRIPTION
### New Intended Behavior

Two new jobs are added to support versioned-deployment work: `deploy-to-prod` & `deploy-to-nonprod`. They use the new work in API repo as part of the same effort.

See confluence documentation here: https://mgmdigitalventures.atlassian.net/wiki/spaces/SER/pages/233440079/Versioned+Deployment+Automation+DRAFT

### JIRA
https://mgmdigitalventures.atlassian.net/browse/SRV-2349