### PR TITLE
f/SRV-2738: Cucumber Xray Jira Integration

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -461,23 +461,62 @@ commands:
             # run dangerfile
             ./node_modules/.bin/danger ci --failOnErrors
 
-  publish-unit-test-results-to-xray:
+  publish-unit-test-results-via-xray:
     description: Publish all unit test results to Jira Xray
     steps:
-      - run:
-          name: Download publish to Xray script
-          when: always
-          command: |
-            # get push-test-results-to-xray.sh
-             wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/xray-r2.3/.circleci/push-test-results-to-xray.sh -O push-test-results-to-xray.sh
+      - attach_workspace:
+            at: .
       - run:
           name: Upload Mocha unit test results to Jira Xray
           when: always
           command: |
-            # run script to push results to Jira
-            bash /home/circleci/project/push-test-results-to-xray.sh ./reports/unit-test-mocha-results.xml SRV junit
+            TEST_RESULTS_FILE=./reports/unit-test-mocha-results.xml
+            PROJECT_CODE=SRV
+            echo "Push Xray Version 1.0.1"
+            echo "File to process: $TEST_RESULTS_FILE"
+            echo "CIRCLE_SHA1 = $CIRCLE_SHA1"
+            if ! test -f $TEST_RESULTS_FILE; then
+              echo "mocha test results file not found ($TEST_RESULTS_FILE)"
+              exit 1
+            fi
+            XRAY_AUTH_TOKEN=$(\
+              curl -s https://xray.cloud.xpand-it.com/api/v1/authenticate \
+                -H "Content-Type: application/json" -X POST \
+                --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
+                | tr -d '"'
+            )
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=$PROJECT_CODE&revision=$CIRCLE_SHA1" \
+              -H "Content-Type: text/xml" \
+              -X POST \
+              -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \
+              --data @"$TEST_RESULTS_FILE"
+            )"
+      - run:
+          name: Upload Cucumber unit test results to Jira Xray
+          when: always
+          command: |
+            TEST_RESULTS_FILE=./reports/unit-test-results.json
+            echo "Push Xray Version 1.0.1"
+            echo "File to process: $TEST_RESULTS_FILE"
+            if ! test -f $TEST_RESULTS_FILE; then
+              echo "cucumber test results file not found ($TEST_RESULTS_FILE)"
+              exit 1
+            fi
+            XRAY_AUTH_TOKEN=$(\
+              curl -s https://xray.cloud.xpand-it.com/api/v1/authenticate \
+                -H "Content-Type: application/json" -X POST \
+                --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
+                | tr -d '"'
+            )
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/cucumber" \
+              -H "Content-Type: application/json" \
+                -X POST \
+                -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \
+                --data @"$TEST_RESULTS_FILE"
+              )"
 
-  publish-integration-test-results-to-xray:
+
+  publish-integration-test-results-via-xray:
     description: Publish all integration test results to Jira Xray
     steps:
       - run:

--- a/microservices.yml
+++ b/microservices.yml
@@ -128,6 +128,11 @@ commands:
           path: ./reports
       - store_artifacts:
           path: ./reports
+      - persist_to_workspace:
+          root: .
+          paths:
+            - reports/unit-test-mocha-results.xml
+            - reports/unit-test-results.json
 
   run-integration-tests-in-docker:
     description: Runs integration tests in docker container
@@ -146,6 +151,11 @@ commands:
           path: ./reports
       - store_artifacts:
           path: ./reports
+      - persist_to_workspace:
+          root: .
+          paths:
+            - reports/integration-test-mocha-results.xml
+            - reports/integration-test-results.json
 
   run-lint:
     description: Runs lint

--- a/microservices.yml
+++ b/microservices.yml
@@ -471,7 +471,6 @@ commands:
           when: always
           command: |
             TEST_RESULTS_FILE=./reports/unit-test-mocha-results.xml
-            PROJECT_CODE=SRV
             echo "Push Xray Version 1.0.1"
             echo "File to process: $TEST_RESULTS_FILE"
             echo "CIRCLE_SHA1 = $CIRCLE_SHA1"
@@ -485,7 +484,7 @@ commands:
                 --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
                 | tr -d '"'
             )
-            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=$PROJECT_CODE&revision=$CIRCLE_SHA1" \
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=SRV&revision=$CIRCLE_SHA1" \
               -H "Content-Type: text/xml" \
               -X POST \
               -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \
@@ -526,7 +525,6 @@ commands:
           when: always
           command: |
             TEST_RESULTS_FILE=./reports/integration-test-mocha-results.xml
-            PROJECT_CODE=SRV
             echo "Push Xray Version 1.0.1"
             echo "File to process: $TEST_RESULTS_FILE"
             echo "CIRCLE_SHA1 = $CIRCLE_SHA1"
@@ -540,7 +538,7 @@ commands:
                 --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
                 | tr -d '"'
             )
-            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=$PROJECT_CODE&revision=$CIRCLE_SHA1" \
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=SRV&revision=$CIRCLE_SHA1" \
               -H "Content-Type: text/xml" \
               -X POST \
               -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \

--- a/microservices.yml
+++ b/microservices.yml
@@ -642,7 +642,11 @@ jobs:
             - populate-env-vars-into-job
             - populate-test-configs-from-workspace
             - run-unit-tests-in-docker
-            - publish-unit-test-results-to-xray
+            
+  publish-unit-test-results-to-xray:
+    executor: vpn/aws
+    steps:
+    - publish-unit-test-results-via-xray
 
   # Step 3b: Verify that integration tests are passing
   run-integration-tests:
@@ -655,7 +659,11 @@ jobs:
             - populate-env-vars-into-job
             - populate-test-configs-from-workspace
             - run-integration-tests-in-docker
-            - publish-integration-test-results-to-xray
+  
+  publish-integration-test-results-to-xray:
+    executor: vpn/aws
+    steps:
+    - publish-integration-test-results-via-xray
 
   # Step 3c: Verify that lint is passing
   run-lint:

--- a/microservices.yml
+++ b/microservices.yml
@@ -519,18 +519,56 @@ commands:
   publish-integration-test-results-via-xray:
     description: Publish all integration test results to Jira Xray
     steps:
-      - run:
-          name: Download publish to Xray script
-          when: always
-          command: |
-            # get push-test-results-to-xray.sh
-            wget https://raw.githubusercontent.com/MGMDV-Orbs/microservices/f/xray-r2.3/.circleci/push-test-results-to-xray.sh -O push-test-results-to-xray.sh
+      - attach_workspace:
+          at: .
       - run:
           name: Upload Mocha integration test results to Jira Xray
           when: always
           command: |
-            # run script to push results to Jira
-            bash /home/circleci/project/push-test-results-to-xray.sh ./reports/integration-test-mocha-results.xml SRV junit
+            TEST_RESULTS_FILE=./reports/integration-test-mocha-results.xml
+            PROJECT_CODE=SRV
+            echo "Push Xray Version 1.0.1"
+            echo "File to process: $TEST_RESULTS_FILE"
+            echo "CIRCLE_SHA1 = $CIRCLE_SHA1"
+            if ! test -f $TEST_RESULTS_FILE; then
+              echo "mocha test results file not found ($TEST_RESULTS_FILE)"
+              exit 1
+            fi
+            XRAY_AUTH_TOKEN=$(\
+              curl -s https://xray.cloud.xpand-it.com/api/v1/authenticate \
+                -H "Content-Type: application/json" -X POST \
+                --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
+                | tr -d '"'
+            )
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/junit?projectKey=$PROJECT_CODE&revision=$CIRCLE_SHA1" \
+              -H "Content-Type: text/xml" \
+              -X POST \
+              -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \
+              --data @"$TEST_RESULTS_FILE"
+            )"
+      - run:
+          name: Upload Cucumber integration test results to Jira Xray
+          when: always
+          command: |
+            TEST_RESULTS_FILE=./reports/integration-test-results.json
+            echo "Push Xray Version 1.0.1"
+            echo "File to process: $TEST_RESULTS_FILE"
+            if ! test -f $TEST_RESULTS_FILE; then
+              echo "cucumber test results file not found ($TEST_RESULTS_FILE)"
+              exit 1
+            fi
+            XRAY_AUTH_TOKEN=$(\
+              curl -s https://xray.cloud.xpand-it.com/api/v1/authenticate \
+                -H "Content-Type: application/json" -X POST \
+                --data "{ \"client_id\": \"$XRAY_CLIENT_ID\", \"client_secret\": \"$XRAY_CLIENT_SECRET\" }" \
+                | tr -d '"'
+            )
+            echo "UPLOAD_RESULT = $(\curl "https://xray.cloud.xpand-it.com/api/v1/import/execution/cucumber" \
+              -H "Content-Type: application/json" \
+                -X POST \
+                -H "Authorization: Bearer $XRAY_AUTH_TOKEN" \
+                --data @"$TEST_RESULTS_FILE"
+              )"
 
 jobs:
   publish-aws-lambdas:


### PR DESCRIPTION
This PR: 
- adds `publish-unit-test-results-via-xray` and `publish-integration-test-results-via-xray` commands
- adds `publish-unit-test-results-to-xray` and `publish-integration-test-results-to-xray` jobs
- persists mocha and cucumber unit + integration test reports to workspace to enable usage across jobs
- removes `push-test-results-xray.sh` script as the logic has been transferred