### PR TITLE
d/SRV-3774: ms/push-image-prod failed

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -106,7 +106,7 @@ commands:
             echo "export ECR_APP_IMAGE=$(aws sts get-caller-identity | jq -r '.Account').dkr.ecr.us-west-2.amazonaws.com/$SERVICE" >> $BASH_ENV
             echo "Manually set ECR_APP_IMAGE to $ECR_APP_IMAGE_ORIGINAL for prod aws account access"
             . $BASH_ENV
-            make build tag push-image-to-ecr
+            make build tag push-image-to-prod-ecr
       - run:
           name: Reset CircleCI branch env var
           command: |

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.16"
+  "version": "2.2.17"
 }


### PR DESCRIPTION
This PR: 
- Updates **push-built-image-to-prod-ecr** command to call **push-image-to-prod-ecr** make command specific for production flows