### PR TITLE
Bump version to proper version to reflect push-image-to-prod-ecr change

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.17"
+  "version": "2.2.19"
 }


### PR DESCRIPTION
This PR: 
- Bumps version to proper version (2.2.19) to reflect push-image-to-prod-ecr change