### PR TITLE
2019 11 25 prod #2

### DIFF
--- a/microservices.yml
+++ b/microservices.yml
@@ -335,7 +335,7 @@ commands:
       - run:
           name: Set static AWS resource names based on AWS account
           command: |
-            . $BASH_ENV
+            . $BASH_ENV || echo 'ok'
             case "$CIRCLE_BRANCH" in
             "prod")
                 echo "Using prod resources"

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "name": "mgmorbs/microservices",
-  "version": "2.2.23"
+  "version": "2.2.24"
 }


### PR DESCRIPTION
This PR: 
- adds fail safe to `Set static AWS resource names based on AWS account` step
- bumps minor version to v2.2.24